### PR TITLE
refactor(buffers): use buffer lists instead of a circular buffer

### DIFF
--- a/lib/codec.js
+++ b/lib/codec.js
@@ -3,7 +3,6 @@
 var debug = require('debug')('amqp10-Codec'),
     util = require('util'),
     butils = require('butils'),
-    CBuffer = require('cbarrick-circular-buffer'),
     builder = require('buffer-builder'),
     Int64 = require('node-int64'),
 
@@ -33,11 +32,11 @@ Codec.prototype._remaining = function(buf, offset) {
 };
 
 Codec.prototype._peek = function(buf, offset, numBytes) {
-  return (buf instanceof CBuffer) ? buf.peek(numBytes + offset).slice(offset) : buf.slice(offset, offset + numBytes);
+  return buf.slice(offset, offset + numBytes);
 };
 
 Codec.prototype._read = function(buf, offset, numBytes) {
-  return (buf instanceof CBuffer) ? buf.read(numBytes + offset).slice(offset) : buf.slice(offset, offset + numBytes);
+  return buf.slice(offset, offset + numBytes);
 };
 
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -7,7 +7,7 @@ var EventEmitter = require('events').EventEmitter,
     util = require('util'),
 
     debug = require('debug')('amqp10-Connection'),
-    cbuf = require('cbarrick-circular-buffer'),
+    BufferList = require('bl'),
     StateMachine = require('stately.js'),
 
     constants = require('./constants'),
@@ -155,7 +155,7 @@ function Connection(connectPolicy) {
   this.client = null;
   this.connected = false;
   this.connectedTo = null;
-  this._curbuf = new cbuf({ size: 1024, encoding: 'buffer' });
+  this._buffer = new BufferList();
   this.connectionParams = {
     containerId: (typeof options.containerId === 'function') ? options.containerId() : options.containerId,
     hostname: options.hostname,
@@ -360,7 +360,7 @@ Connection.prototype._processError = function(err) {
 
 Connection.prototype._receiveData = function(buffer) {
   debug('Rx: ' + buffer.toString('hex'));
-  this._curbuf.write(buffer);
+  this._buffer.append(buffer);
   this._receiveAny();
 };
 
@@ -372,8 +372,10 @@ Connection.prototype.sendHeader = function(header) {
 
 Connection.prototype._tryReceiveHeader = function(header) {
   header = header || constants.amqpVersion;
-  if (this._curbuf.length >= header.length) {
-    var serverVersion = this._curbuf.read(8);
+  if (this._buffer.length >= header.length) {
+    var serverVersion = this._buffer.slice(0, 8);
+    this._buffer.consume(8);
+
     if (this.sasl) {
       this.sasl.headerReceived(serverVersion);
     } else {
@@ -398,12 +400,12 @@ Connection.prototype._tryReceiveHeader = function(header) {
 
 Connection.prototype._tryReceiveFrame = function() {
   try {
-    var frame = FrameReader.read(this._curbuf);
+    var frame = FrameReader.read(this._buffer);
     if (frame === undefined) {
     //debug('Not enough frame');
     } else {
       //debug('Matched frame: ' + frame.constructor.name + ': ' + JSON.stringify(frame));
-      //debug(this._curbuf.length + ' bytes left');
+      //debug(this._buffer.length + ' bytes left');
     }
     return frame;
   } catch (e) {
@@ -486,7 +488,7 @@ Connection.prototype._processOpenFrame = function(frame) {
       }
     }, timeBetweenHeartbeatChecks);
     this.emit(Connection.Connected, this);
-    if (this._curbuf.length) this._receiveAny(); // Might have more frames pending.
+    if (this._buffer.length) this._receiveAny(); // Might have more frames pending.
   }
 };
 

--- a/lib/frames/frame_reader.js
+++ b/lib/frames/frame_reader.js
@@ -36,29 +36,35 @@ function FrameReader() {
  * @todo Need to process the payloads as well
  * @todo Cope with Non-AMQP frames
  *
- * @param cbuf          circular buffer containing the potential frame data.
+ * @param buffer       Buffer containing the potential frame data.
  * @return {AMQPFrame} Frame with populated data, undefined if frame is incomplete.  Throws exception on unmatched frame.
  */
-FrameReader.prototype.read = function(cbuf) {
-  if (cbuf.length < 8) return undefined;
+FrameReader.prototype.read = function(buffer) {
+  if (buffer.length < 8) return undefined;
 
-  var size = cbuf.peek(4).readUInt32BE(0);
-  if (size > cbuf.length) return undefined;
+  var size = buffer.slice(0, 4).readUInt32BE(0);
+  if (size > buffer.length) return undefined;
 
-  var sizeAndDoff = cbuf.read(8);
+  var sizeAndDoff = buffer.slice(0, 8);
+  buffer.consume(8);
+
   var doff = sizeAndDoff[4];
   var frameType = sizeAndDoff[5];
   var xHeaderSize = (doff * 4) - 8;
   var payloadSize = size - (doff * 4);
   if (xHeaderSize > 0) {
-    var xHeaderBuf = cbuf.read(xHeaderSize);
+    var xHeaderBuf = buffer.slice(0, xHeaderSize);
+    buffer.consume(xHeaderSize);
+
     // @todo Process x-header
     debug('Read extended header [' + xHeaderBuf.toString('hex') + ']');
   }
 
   var payloadBuf = null;
   if (payloadSize > 0) {
-    payloadBuf = cbuf.read(payloadSize);
+    payloadBuf = buffer.slice(0, payloadSize);
+    buffer.consume(payloadSize);
+
     if (frameType === constants.frameType.amqp) {
       var channel = sizeAndDoff.readUInt16BE(6); // Bytes 6 & 7 are channel
       var decoded = codec.decode(payloadBuf, 0);

--- a/lib/types.js
+++ b/lib/types.js
@@ -3,7 +3,6 @@
 var debug = require('debug')('amqp10-types'),
     butils = require('butils'),
     builder = require('buffer-builder'),
-    CBuffer = require('cbarrick-circular-buffer'),
     Int64 = require('node-int64'),
 
     exceptions = require('./exceptions'),

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "buffer-builder": "^0.2.0",
     "butils": "^0.1.0",
-    "cbarrick-circular-buffer": "^1.2.2",
+    "bl": "^0.9.4",
     "debug": "^2.0.0",
     "node-amqp-encoder": "^0.0.2",
     "node-int64": "^0.3.2",

--- a/test/test_codec.js
+++ b/test/test_codec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var Int64 = require('node-int64'),
-    CBuffer = require('cbarrick-circular-buffer'),
     should = require('should'),
     debug = require('debug')('amqp10-test-codec'),
     builder = require('buffer-builder'),
@@ -15,30 +14,29 @@ var Int64 = require('node-int64'),
 
     tu = require('./testing_utils');
 
-var newBuf = tu.newBuf;
-
-var newCBuf = tu.newCBuf;
+var buildBuffer = tu.buildBuffer;
+var newBuffer = tu.newBuffer;
 
 describe('Codec', function() {
   describe('#decode()', function() {
 
     it('should match fixed values', function() {
-      var buffer = newCBuf([0x50, 0x05]);
+      var buffer = newBuffer([0x50, 0x05]);
       var actual = codec.decode(buffer);
       actual[0].should.eql(5);
       actual[1].should.eql(2);
     });
 
     it('should match simple values', function() {
-      (codec.decode(newCBuf([0x40]))[0] === null).should.be.true;
-      codec.decode(newCBuf([0x41]))[0].should.be.true;
-      codec.decode(newCBuf([0x42]))[0].should.be.false;
-      codec.decode(newCBuf([0x43]))[0].should.eql(0);
-      codec.decode(newCBuf([0x44]))[0].should.eql(new Int64(0, 0));
+      (codec.decode(newBuffer([0x40]))[0] === null).should.be.true;
+      codec.decode(newBuffer([0x41]))[0].should.be.true;
+      codec.decode(newBuffer([0x42]))[0].should.be.false;
+      codec.decode(newBuffer([0x43]))[0].should.eql(0);
+      codec.decode(newBuffer([0x44]))[0].should.eql(new Int64(0, 0));
     });
 
     it('should match longs', function() {
-      var buffer = newCBuf([0x80, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
+      var buffer = newBuffer([0x80, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80]);
       var actual = codec.decode(buffer);
       actual[0].should.eql(new Int64(new Buffer([0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80])));
       actual[1].should.eql(9);
@@ -46,45 +44,45 @@ describe('Codec', function() {
 
     it('should match floats', function() {
       var expected = new Buffer([0x01, 0x02, 0x03, 0x04]).readFloatBE(0);
-      var buffer = newCBuf([0x72, 0x01, 0x02, 0x03, 0x04]);
+      var buffer = newBuffer([0x72, 0x01, 0x02, 0x03, 0x04]);
       var actual = codec.decode(buffer);
       actual[0].should.eql(expected);
       actual[1].should.eql(5);
 
       expected = new Buffer([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]).readDoubleBE(0);
-      buffer = newCBuf([0x82, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
+      buffer = newBuffer([0x82, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]);
       actual = codec.decode(buffer);
       actual[0].should.eql(expected);
       actual[1].should.eql(9);
     });
 
     it('should match strings', function() {
-      var buffer = newCBuf([0xA1, 0x3, 0x46, 0x4F, 0x4F]);
+      var buffer = newBuffer([0xA1, 0x3, 0x46, 0x4F, 0x4F]);
       var actual = codec.decode(buffer);
       actual[0].should.eql('FOO');
       actual[1].should.eql(5);
 
-      buffer = newCBuf([0xB1, 0x0, 0x0, 0x0, 0x3, 0x46, 0x4F, 0x4F]);
+      buffer = newBuffer([0xB1, 0x0, 0x0, 0x0, 0x3, 0x46, 0x4F, 0x4F]);
       actual = codec.decode(buffer);
       actual[0].should.eql('FOO');
       actual[1].should.eql(8);
     });
 
     it('should match buffers', function() {
-      var buffer = newCBuf([0xA0, 0x3, 0x7b, 0x22, 0x7d]);
+      var buffer = newBuffer([0xA0, 0x3, 0x7b, 0x22, 0x7d]);
       var actual = codec.decode(buffer);
       actual[0].should.be.instanceof(Buffer);
-      tu.shouldBufEql(newBuf([0x7b, 0x22, 0x7d]), actual[0]);
+      tu.shouldBufEql(buildBuffer([0x7b, 0x22, 0x7d]), actual[0]);
       actual[1].should.eql(5);
     });
 
     it('should fail when not implemented', function() {
-      var buffer = newCBuf([0x73, 0x01, 0x02, 0x03, 0x04]);
+      var buffer = newBuffer([0x73, 0x01, 0x02, 0x03, 0x04]);
       (function() { codec.decode(buffer); }).should.throw(Error);   // jshint ignore:line
     });
 
     it('should decode described types', function() {
-      var buffer = newCBuf([0x00, 0xA1, 0x03, builder.prototype.appendString, 'URL', 0xA1, 0x1E, builder.prototype.appendString, 'http://example.org/hello-world']);
+      var buffer = newBuffer([0x00, 0xA1, 0x03, builder.prototype.appendString, 'URL', 0xA1, 0x1E, builder.prototype.appendString, 'http://example.org/hello-world']);
       var actual = codec.decode(buffer);
       actual[0].should.be.instanceof(DescribedType);
       actual[0].descriptor.should.eql('URL');
@@ -92,7 +90,7 @@ describe('Codec', function() {
     });
 
     it('should decode nested described types', function() {
-      var buffer = newCBuf([0x00, 0xA1, 3, builder.prototype.appendString, 'FOO', 0x00, 0xA1, 3, builder.prototype.appendString, 'BAR', 0xA1, 3, builder.prototype.appendString, 'BAZ']);
+      var buffer = newBuffer([0x00, 0xA1, 3, builder.prototype.appendString, 'FOO', 0x00, 0xA1, 3, builder.prototype.appendString, 'BAR', 0xA1, 3, builder.prototype.appendString, 'BAZ']);
       var actual = codec.decode(buffer);
       actual[0].should.be.instanceof(DescribedType);
       actual[0].value.should.be.instanceof(DescribedType);
@@ -103,7 +101,7 @@ describe('Codec', function() {
 
     it('should decode nested described and composites', function() {
       // Described (int64(0x1), [ Described(int64(0x2), 'VAL') ])
-      var buffer = newCBuf([0x00, 0x53, 0x1, 0xC0, (1 + 1 + 2 + 1 + 1 + 3), 1, 0x00, 0x53, 0x2, 0xA1, 3, builder.prototype.appendString, 'VAL']);
+      var buffer = newBuffer([0x00, 0x53, 0x1, 0xC0, (1 + 1 + 2 + 1 + 1 + 3), 1, 0x00, 0x53, 0x2, 0xA1, 3, builder.prototype.appendString, 'VAL']);
       var actual = codec.decode(buffer);
       actual[0].should.be.instanceof(DescribedType);
       actual[0].value.should.be.instanceof(Array);
@@ -115,7 +113,7 @@ describe('Codec', function() {
     });
 
     it('should decode forced-type values', function() {
-      var buffer = newBuf([0x03, builder.prototype.appendString, 'URL']);
+      var buffer = buildBuffer([0x03, builder.prototype.appendString, 'URL']);
       var actual = codec.decode(buffer, 0, 0xA3);
       actual[0].should.be.instanceof(AMQPSymbol);
       actual[0].contents.should.eql('URL');
@@ -124,7 +122,7 @@ describe('Codec', function() {
 
     it('should decode composite example from spec', function() {
       // From Page 25 of AMQP 1.0 spec
-      var buffer = newBuf([0x00, 0xA3, 0x11,
+      var buffer = buildBuffer([0x00, 0xA3, 0x11,
         builder.prototype.appendString, 'example:book:list',
         0xC0, 0x40, 0x03, 0xA1, 0x15,
         builder.prototype.appendString, 'AMQP for & by Dummies',
@@ -134,7 +132,7 @@ describe('Codec', function() {
         builder.prototype.appendString, 'Rafael H. Schloming',
         0x40]);
       console.log('Composite type: ' + buffer.toString('hex'));
-      var actual = codec.decode(newCBuf(buffer));
+      var actual = codec.decode(newBuffer(buffer));
       actual[0].should.eql(new DescribedType(new AMQPSymbol('example:book:list'),
           [
            'AMQP for & by Dummies',
@@ -144,24 +142,24 @@ describe('Codec', function() {
     });
 
     it('should decode open frame received from ActiveMQ', function() {
-      var buffer = newBuf([0x00,
+      var buffer = buildBuffer([0x00,
         0x53, 0x10,
         0xc0, 0x0a, 0x03,
         0xa1, 0x00,
         0xa1, 0x00,
         0x70, 0x00, 0x10, 0x00, 0x00]);
-      var actual = codec.decode(newCBuf(buffer));
+      var actual = codec.decode(newBuffer(buffer));
       actual[0].should.eql(new DescribedType(new Int64(0, 0x10), ['', '', 0x00100000]));
     });
 
     it('should decode known type (AMQPError) from described type', function() {
-      var buffer = newBuf([0x00, 0x53, 0x1D,
+      var buffer = buildBuffer([0x00, 0x53, 0x1D,
         0xD0, builder.prototype.appendUInt32BE, (4 + 2 + 19 + 2 + 4 + 3), builder.prototype.appendUInt32BE, 3,
         0xA3, 19, builder.prototype.appendString, 'amqp:internal-error',
         0xA1, 4, builder.prototype.appendString, 'test',
         0xC1, 1, 0x0 // empty info map
       ]);
-      var actual = codec.decode(newCBuf(buffer));
+      var actual = codec.decode(newBuffer(buffer));
       (actual === undefined).should.be.false;
       actual[0].should.be.instanceof(AMQPError);
       actual[0].condition.contents.should.eql('amqp:internal-error');
@@ -182,7 +180,7 @@ describe('Codec', function() {
     });
     it('should encode buffers', function() {
       var bufb = new builder();
-      codec.encode(newBuf([0xFF]), bufb);
+      codec.encode(buildBuffer([0xFF]), bufb);
       tu.shouldBufEql([0xA0, 1, 0xFF], bufb);
     });
     it('should encode long buffers', function() {
@@ -208,23 +206,23 @@ describe('Codec', function() {
 
       bufb = new builder();
       codec.encode(new Int64(0x12, 0x34), bufb);
-      expected = newBuf([0x80, builder.prototype.appendInt32BE, 0x12, builder.prototype.appendInt32BE, 0x34]);
+      expected = buildBuffer([0x80, builder.prototype.appendInt32BE, 0x12, builder.prototype.appendInt32BE, 0x34]);
       tu.shouldBufEql(expected, bufb);
 
       bufb = new builder();
       codec.encode(new Int64(0xFFFFFFFF, 0xFFFFFF00), bufb);
-      expected = newBuf([0x81, builder.prototype.appendInt32BE, 0xFFFFFFFF, builder.prototype.appendInt32BE, 0xFFFFFF00]);
+      expected = buildBuffer([0x81, builder.prototype.appendInt32BE, 0xFFFFFFFF, builder.prototype.appendInt32BE, 0xFFFFFF00]);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode lists', function() {
       var list = [1, 'foo'];
-      var expected = newBuf([0xC0, (1 + 5 + 5), 2, 0x71, 0, 0, 0, 1, 0xA1, 3, builder.prototype.appendString, 'foo']);
+      var expected = buildBuffer([0xC0, (1 + 5 + 5), 2, 0x71, 0, 0, 0, 1, 0xA1, 3, builder.prototype.appendString, 'foo']);
       var bufb = new builder();
       codec.encode(list, bufb);
       tu.shouldBufEql(expected, bufb);
 
       list = [];
-      expected = newBuf([0x45]);
+      expected = buildBuffer([0x45]);
       bufb = new builder();
       codec.encode(list, bufb);
       tu.shouldBufEql(expected, bufb);
@@ -232,13 +230,13 @@ describe('Codec', function() {
     it('should encode described types', function() {
       var bufb = new builder();
       codec.encode(new DescribedType('D1', 'V1'), bufb);
-      var expected = newBuf([0x00, 0xA1, 0x2, builder.prototype.appendString, 'D1', 0xA1, 0x2, builder.prototype.appendString, 'V1']);
+      var expected = buildBuffer([0x00, 0xA1, 0x2, builder.prototype.appendString, 'D1', 0xA1, 0x2, builder.prototype.appendString, 'V1']);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode described types with no values', function() {
       var bufb = new builder();
       codec.encode(new DescribedType(new Int64(0x0, 0x26)), bufb);
-      var expected = newBuf([0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x26, 0x45]);
+      var expected = buildBuffer([0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x26, 0x45]);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode objects as lists when asked', function() {
@@ -247,35 +245,35 @@ describe('Codec', function() {
         bar: 'V2',
         encodeOrdering: ['foo', 'bar']
       };
-      var expected = newBuf([0xC0, 0x9, 0x2, 0xA1, 0x2, builder.prototype.appendString, 'V1', 0xA1, 0x2, builder.prototype.appendString, 'V2']);
+      var expected = buildBuffer([0xC0, 0x9, 0x2, 0xA1, 0x2, builder.prototype.appendString, 'V1', 0xA1, 0x2, builder.prototype.appendString, 'V2']);
       var bufb = new builder();
       codec.encode(toEncode, bufb);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode forced-types when asked', function() {
       var toEncode = new ForcedType('uint', 0x123);
-      var expected = newBuf([0x70, 0x00, 0x00, 0x01, 0x23]);
+      var expected = buildBuffer([0x70, 0x00, 0x00, 0x01, 0x23]);
       var bufb = new builder();
       codec.encode(toEncode, bufb);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode null', function() {
       var toEncode = null;
-      var expected = newBuf([0x40]);
+      var expected = buildBuffer([0x40]);
       var bufb = new builder();
       codec.encode(toEncode, bufb);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode ForcedType with null value as null', function() {
       var toEncode = new ForcedType('uint', null);
-      var expected = newBuf([0x40]);
+      var expected = buildBuffer([0x40]);
       var bufb = new builder();
       codec.encode(toEncode, bufb);
       tu.shouldBufEql(expected, bufb);
     });
     it('should encode amqp arrays', function() {
       var amqpArray = new AMQPArray([1, 2, 3], 0x71);
-      var expected = newBuf([0xE0,
+      var expected = buildBuffer([0xE0,
         /* size = (int32*3 + count + constructor) */ builder.prototype.appendUInt8, (4 * 3 + 1 + 1),
         /* count */ builder.prototype.appendUInt8, 3, /* constructor */ 0x71,
         builder.prototype.appendUInt32BE, 1, builder.prototype.appendUInt32BE, 2, builder.prototype.appendUInt32BE, 3
@@ -286,7 +284,7 @@ describe('Codec', function() {
     });
     it('should encode composite example from spec', function() {
       // From Page 25 of AMQP 1.0 spec
-      var expected = newBuf([0x00, 0xA3, 0x11,
+      var expected = buildBuffer([0x00, 0xA3, 0x11,
         builder.prototype.appendString, 'example:book:list',
         0xC0, 0x40, 0x03, 0xA1, 0x15,
         builder.prototype.appendString, 'AMQP for & by Dummies',
@@ -319,7 +317,7 @@ describe('Codec', function() {
         encodeOrdering: ['id', 'hostname', 'maxFrameSize', 'channelMax', 'idleTimeout', 'outgoingLocales',
           'incomingLocales', 'offeredCapabilities', 'desiredCapabilities', 'properties']
       });
-      var expected = newBuf([0x00,
+      var expected = buildBuffer([0x00,
         0x80, builder.prototype.appendUInt32BE, 0x0, builder.prototype.appendUInt32BE, 0x10, // Descriptor
         // 0xD0, builder.prototype.appendUInt32BE, 0x0, builder.prototype.appendUInt32BE, 0x0, // List (size & count)
         0xC0, (1 + 8 + 11 + 5 + 3 + 5 + 7 + 7 + 1 + 1 + 3), 10,

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -60,7 +60,7 @@ describe('Connection', function() {
                 session.on(Session.LinkAttached, function(link) {
                     var msg = new M.Message();
                     msg.body.push('test message');
-                    session.sendMessage(link, msg, { deliveryId: 1, deliveryTag: tu.newBuf([1]) });
+                    session.sendMessage(link, msg, { deliveryId: 1, deliveryTag: tu.buildBuffer([1]) });
                     setTimeout(function() {
                         session.detachLink(link);
                     }, 500);

--- a/test/test_frame_encodings.js
+++ b/test/test_frame_encodings.js
@@ -32,7 +32,7 @@ describe('OpenFrame', function() {
     it('should encode performative correctly', function() {
       var open = new OpenFrame({ containerId: 'test', hostname: 'localhost' });
       var actual = open.outgoing();
-      var expected = tu.newBuf([
+      var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, 0x46,
         0x02, 0x00, 0x00, 0x00,
         0x00,
@@ -59,7 +59,7 @@ describe('BeginFrame', function() {
       var begin = new BeginFrame({ nextOutgoingId: 1, incomingWindow: 100, outgoingWindow: 100 });
       begin.channel = 1;
       var actual = begin.outgoing();
-      var expected = tu.newBuf([
+      var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, 0x26,
         0x02, 0x00, 0x00, 0x01,
         0x00,
@@ -95,7 +95,7 @@ describe('AttachFrame', function() {
       var listSize = 1 + 6 + 2 + 1 + 2 + 2 + 10 + 2 + sourceSize + 10 + 2 + targetSize + 3 + 1 + 2 + 1 + 1 + 1 + 3;
       var listCount = 14;
       var frameSize = 8 + 1 + 9 + 2 + listSize;
-      var expected = tu.newBuf([
+      var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, frameSize,
         0x02, 0x00, 0x00, 0x01,
         0x00,
@@ -161,7 +161,7 @@ describe('FlowFrame', function() {
       var actual = flow.outgoing();
       var listSize = 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 3;
       var frameSize = 8 + 1 + 9 + 2 + listSize;
-      var expected = tu.newBuf([
+      var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, frameSize,
         0x02, 0x00, 0x00, 0x01,
         0x00,
@@ -191,7 +191,7 @@ describe('TransferFrame', function() {
       var transfer = new TransferFrame({
         handle: 1,
         deliveryId: 1,
-        deliveryTag: tu.newBuf([1]),
+        deliveryTag: tu.buildBuffer([1]),
         messageFormat: 20000,
         settled: true,
         receiverSettleMode: constants.receiverSettleMode.autoSettle
@@ -203,7 +203,7 @@ describe('TransferFrame', function() {
       var payloadSize = 12;
       var listSize = 1 + 2 + 2 + 3 + 5 + 1 + 1 + 2 + 1 + 1 + 1 + 1;
       var frameSize = 8 + 1 + 9 + 2 + listSize + payloadSize;
-      var expected = tu.newBuf([
+      var expected = tu.buildBuffer([
         0x00, 0x00, 0x00, frameSize,
         0x02, 0x00, 0x00, 0x01,
         0x00,
@@ -235,7 +235,7 @@ describe('SaslFrames', function() {
         var mechanisms = new Sasl.SaslMechanisms();
         var actual = mechanisms.outgoing();
         var frameSize = 8 + 1 + 9 + 3 + 2 + 'ANONYMOUS'.length;
-        var expected = tu.newBuf([
+        var expected = tu.buildBuffer([
           0x00, 0x00, 0x00, frameSize,
           0x02, 0x01, 0x00, 0x00,
           0x00,
@@ -255,7 +255,7 @@ describe('HeartbeatFrame', function() {
     it('should encode correctly', function() {
       var heartbeat = new HeartbeatFrame();
       var actual = heartbeat.outgoing();
-      var expected = tu.newBuf([0, 0, 0, 8, 2, 0, 0, 0]);
+      var expected = tu.buildBuffer([0, 0, 0, 8, 2, 0, 0, 0]);
       tu.shouldBufEql(expected, actual);
     });
   });

--- a/test/test_sasl.js
+++ b/test/test_sasl.js
@@ -32,7 +32,7 @@ PolicyBase.connectPolicy.options.containerId = 'test';
 function initBuf() {
   var init = new SaslFrames.SaslInit({
     mechanism: new AMQPSymbol('PLAIN'),
-    initialResponse: tu.newBuf([0, builder.prototype.appendString, 'user', 0, builder.prototype.appendString, 'pass'])
+    initialResponse: tu.buildBuffer([0, builder.prototype.appendString, 'user', 0, builder.prototype.appendString, 'pass'])
   });
   return init.outgoing();
 }

--- a/test/test_types.js
+++ b/test/test_types.js
@@ -13,7 +13,7 @@ var assert = require('assert'),
 
     tu = require('./testing_utils');
 
-var buf = tu.newBuf;
+var buf = tu.buildBuffer;
 
 function assertEncoders(tests, maxSize) {
   for (var idx in tests) {

--- a/test/test_utilities.js
+++ b/test/test_utilities.js
@@ -31,20 +31,20 @@ describe('Utilities', function() {
 
   describe('#bufferEquals()', function() {
     it('should succeed when equal', function() {
-      var b1 = tu.newBuf([1, 2, 3, 4]);
-      var b2 = tu.newBuf([1, 2, 3, 4]);
+      var b1 = tu.buildBuffer([1, 2, 3, 4]);
+      var b2 = tu.buildBuffer([1, 2, 3, 4]);
       u.bufferEquals(b1, b2).should.be.true;
     });
     it('should only operate on slices expected', function() {
-      var b1 = tu.newBuf([1, 2, 3, 4, 5]);
-      var b2 = tu.newBuf([2, 3, 4, 5, 6]);
+      var b1 = tu.buildBuffer([1, 2, 3, 4, 5]);
+      var b2 = tu.buildBuffer([2, 3, 4, 5, 6]);
       u.bufferEquals(b1, b2, 1, 0, 4).should.be.true;
     });
     it('should return false quickly on unequal size buffers', function() {
       // Ideally, I'd use two huge buffers, set the timeout low, and ensure the test passes in the time allotted,
       //  but that's (a) a pain, and (b) prone to sporadic failures, so just ensuring it at least gives the right answer.
-      var b1 = tu.newBuf([1]);
-      var b2 = tu.newBuf([1, 2]);
+      var b1 = tu.buildBuffer([1]);
+      var b2 = tu.buildBuffer([1, 2]);
       u.bufferEquals(b1, b2).should.be.false;
     });
   });

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var builder = require('buffer-builder'),
-    CBuffer = require('cbarrick-circular-buffer'),
+    BufferList = require('bl'),
     should = require('should');
 
-function newBuf(contents) {
+function buildBuffer(contents) {
   var bufb = new builder();
   for (var idx = 0; idx < contents.length; idx++) {
     var cur = contents[idx];
@@ -17,16 +17,15 @@ function newBuf(contents) {
   return bufb.get();
 }
 
-module.exports.newBuf = newBuf;
+module.exports.buildBuffer = buildBuffer;
 
-function newCBuf(contents) {
-  var buf = newBuf(contents);
-  var cbuf = new CBuffer({ size: buf.length, encoding: 'buffer' });
-  cbuf.write(buf);
-  return cbuf;
+function newBuffer(contents) {
+  var buffer = new BufferList();
+  buffer.append(buildBuffer(contents));
+  return buffer;
 }
 
-module.exports.newCBuf = newCBuf;
+module.exports.newBuffer = newBuffer;
 
 function shouldBufEql(expected, actual, msg) {
   msg = msg ? msg + ': ' : '';
@@ -34,7 +33,7 @@ function shouldBufEql(expected, actual, msg) {
     actual = actual.get();
   }
   if (expected instanceof Array) {
-    expected = newBuf(expected);
+    expected = buildBuffer(expected);
   }
 
   var expectedStr = expected.toString('hex');


### PR DESCRIPTION
Closes https://github.com/noodlefrenzy/node-amqp-1-0/issues/35, possibly https://github.com/noodlefrenzy/node-amqp-1-0/issues/47 as well

This was a pretty straight-forward port, and seems to have resolved the parsing issues I was seeing previously. I've intentionally left the sort of awkward combination of "slice(0, offset); consume(offset)" in the code as a sort of reminder that we should eventually be using streams/token-parser, but this is a good stopgap for the moment.