### PR TITLE
refactor(defaults): use lodash defaults instead of custom utilities

### DIFF
--- a/lib/frames/attach_frame.js
+++ b/lib/frames/attach_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-AttachFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -164,27 +165,30 @@ function AttachFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['name', 'handle', 'role']);
-    if (!options.source && !options.target) throw new exceptions.ArgumentError('source|target');
-    if (options.role === constants.linkRole.sender &&
-            options.initialDeliveryCount === undefined) throw new exceptions.ArgumentError('initialDeliveryCount for sender');
-
-    this.name = options.name;
-    this.handle = options.handle;
-    this.role = options.role;
-    this.senderSettleMode = u.onUndef(options.senderSettleMode, constants.senderSettleMode.mixed);
-    this.receiverSettleMode = u.onUndef(options.receiverSettleMode, constants.receiverSettleMode.autoSettle);
-    this.source = u.orNull(options.source);
-    this.target = u.orNull(options.target);
-    this.unsettled = u.onUndef(options.unsettled, {});
-    this.incompleteUnsettled = u.orFalse(options.incompleteUnsettled);
-    this.initialDeliveryCount = u.orNull(options.initialDeliveryCount);
-    this.maxMessageSize = u.onUndef(options.maxMessageSize, 0);
-    this.offeredCapabilities = u.orNull(options.offeredCapabilities);
-    this.desiredCapabilities = u.orNull(options.desiredCapabilities);
-    this.properties = u.onUndef(options.properties, {});
+    return 0;
   }
+
+  exceptions.assertArguments(options, ['name', 'handle', 'role']);
+  if (!options.source && !options.target)
+    throw new exceptions.ArgumentError('source|target');
+
+  if (options.role === constants.linkRole.sender &&
+      options.initialDeliveryCount === undefined)
+    throw new exceptions.ArgumentError('initialDeliveryCount for sender');
+
+  _.defaults(this, options, {
+    senderSettleMode: constants.senderSettleMode.mixed,
+    receiverSettleMode: constants.receiverSettleMode.autoSettle,
+    source: null,
+    target: null,
+    unsettled: {},
+    incompleteUnsettled: false,
+    initialDeliveryCount: null,
+    maxMessageSize: 0,
+    offeredCapabilities: null,
+    desiredCapabilities: null,
+    properties: {}
+  });
 }
 
 util.inherits(AttachFrame, FrameBase.AMQPFrame);

--- a/lib/frames/begin_frame.js
+++ b/lib/frames/begin_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-BeginFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -88,18 +89,17 @@ function BeginFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['nextOutgoingId', 'incomingWindow', 'outgoingWindow']);
-    this.channel = u.onUndef(options.channel, this.channel);
-    this.remoteChannel = u.orNull(options.remoteChannel);
-    this.nextOutgoingId = options.nextOutgoingId;
-    this.incomingWindow = options.incomingWindow;
-    this.outgoingWindow = options.outgoingWindow;
-    this.handleMax = u.onUndef(options.handleMax, constants.defaultHandleMax);
-    this.offeredCapabilities = u.orNull(options.offeredCapabilities);
-    this.desiredCapabilities = u.orNull(options.desiredCapabilities);
-    this.properties = u.onUndef(options.properties, {});
+    return;
   }
+
+  exceptions.assertArguments(options, ['nextOutgoingId', 'incomingWindow', 'outgoingWindow']);
+  _.defaults(this, options, {
+    remoteChannel: null,
+    handleMax: constants.defaultHandleMax,
+    offeredCapabilities: null,
+    desiredCapabilities: null,
+    properties: {}
+  });
 }
 
 util.inherits(BeginFrame, FrameBase.AMQPFrame);

--- a/lib/frames/detach_frame.js
+++ b/lib/frames/detach_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-DetachFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -54,12 +55,14 @@ function DetachFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['handle']);
-    this.handle = options.handle;
-    this.closed = u.orFalse(options.closed);
-    this.error = u.orNull(options.error);
+    return;
   }
+
+  exceptions.assertArguments(options, ['handle']);
+  _.defaults(this, options, {
+    closed: false,
+    error: null
+  });
 }
 
 util.inherits(DetachFrame, FrameBase.AMQPFrame);

--- a/lib/frames/disposition_frame.js
+++ b/lib/frames/disposition_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-DispositionFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -94,15 +95,16 @@ function DispositionFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['role', 'first']);
-    this.role = options.role;
-    this.first = options.first;
-    this.last = u.onUndef(options.last, 0);
-    this.settled = u.orFalse(options.settled);
-    this.state = u.orNull(options.state);
-    this.batchable = u.orFalse(options.batchable);
+    return;
   }
+
+  exceptions.assertArguments(options, ['role', 'first']);
+  _.defaults(this, options, {
+    last: 0,
+    settled: false,
+    state: null,
+    batchable: false
+  });
 }
 
 util.inherits(DispositionFrame, FrameBase.AMQPFrame);

--- a/lib/frames/flow_frame.js
+++ b/lib/frames/flow_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-FlowFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -148,21 +149,20 @@ function FlowFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['incomingWindow', 'nextOutgoingId', 'outgoingWindow']);
-
-    this.nextIncomingId = u.orNull(options.nextIncomingId);
-    this.incomingWindow = options.incomingWindow;
-    this.nextOutgoingId = options.nextOutgoingId;
-    this.outgoingWindow = options.outgoingWindow;
-    this.handle = u.orNull(options.handle);
-    this.deliveryCount = u.orNull(options.deliveryCount);
-    this.linkCredit = u.orNull(options.linkCredit);
-    this.available = u.orNull(options.available);
-    this.drain = u.orFalse(options.drain);
-    this.echo = u.orFalse(options.echo);
-    this.properties = u.onUndef(options.properties, {});
+    return;
   }
+
+  exceptions.assertArguments(options, ['incomingWindow', 'nextOutgoingId', 'outgoingWindow']);
+  _.defaults(this, options, {
+    nextIncomingId: null,
+    handle: null,
+    deliveryCount: null,
+    linkCredit: null,
+    available: null,
+    drain: false,
+    echo: false,
+    properties: {}
+  });
 }
 
 util.inherits(FlowFrame, FrameBase.AMQPFrame);

--- a/lib/frames/open_frame.js
+++ b/lib/frames/open_frame.js
@@ -3,6 +3,7 @@
 var debug = require('debug')('amqp10-OpenFrame'),
     Int64 = require('node-int64'),
     util = require('util'),
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -151,19 +152,21 @@ function OpenFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['containerId', 'hostname']);
-    this.id = options.containerId;
-    this.hostname = options.hostname;
-    this.maxFrameSize = u.onUndef(options.maxFrameSize, constants.defaultMaxFrameSize);
-    this.channelMax = u.onUndef(options.channelMax, constants.defaultChannelMax);
-    this.idleTimeout = u.onUndef(options.idleTimeout, constants.defaultIdleTimeout);
-    this.outgoingLocales = u.onUndef(options.outgoingLocales, constants.defaultOutgoingLocales);
-    this.incomingLocales = u.onUndef(options.incomingLocales, constants.defaultIncomingLocales);
-    this.offeredCapabilities = u.orNull(options.offeredCapabilities);
-    this.desiredCapabilities = u.orNull(options.desiredCapabilities);
-    this.properties = u.onUndef(options.properties, {});
+    return;
   }
+
+  exceptions.assertArguments(options, ['containerId', 'hostname']);
+  this.id = options.containerId;
+  _.defaults(this, options, {
+    maxFrameSize: constants.defaultMaxFrameSize,
+    channelMax: constants.defaultChannelMax,
+    idleTimeout: constants.defaultIdleTimeout,
+    outgoingLocales: constants.defaultOutgoingLocales,
+    incomingLocales: constants.defaultIncomingLocales,
+    offeredCapabilities: null,
+    desiredCapabilities: null,
+    properties: {}
+  });
 }
 
 util.inherits(OpenFrame, FrameBase.AMQPFrame);

--- a/lib/frames/transfer_frame.js
+++ b/lib/frames/transfer_frame.js
@@ -4,6 +4,7 @@ var debug = require('debug')('amqp10-TransferFrame'),
     util = require('util'),
     Int64 = require('node-int64'),
     Builder = require('node-amqp-encoder').Builder,
+    _ = require('lodash'),
 
     constants = require('../constants'),
     exceptions = require('../exceptions'),
@@ -190,23 +191,22 @@ function TransferFrame(options) {
   this.channel = 0;
   if (options instanceof DescribedType) {
     this.readPerformative(options);
-  } else {
-    exceptions.assertArguments(options, ['handle']);
-
-    this.handle = options.handle;
-    this.deliveryId = u.orNull(options.deliveryId);
-    this.deliveryTag = u.orNull(options.deliveryTag);
-    this.messageFormat = u.orNull(options.messageFormat);
-    this.settled = u.orNull(options.settled);
-    this.more = u.orFalse(options.more);
-    this.receiverSettleMode = u.orNull(options.receiverSettleMode);
-    this.state = u.orNull(options.state);
-    this.resume = u.orFalse(options.resume);
-    this.aborted = u.orFalse(options.aborted);
-    this.batchable = u.orFalse(options.batchable);
-
-    this.message = options.message;
+    return;
   }
+
+  exceptions.assertArguments(options, ['handle']);
+  _.defaults(this, options, {
+    deliveryId: null,
+    deliveryTag: null,
+    messageFormat: null,
+    settled: null,
+    more: false,
+    receiverSettleMode: null,
+    state: null,
+    resume: false,
+    aborted: false,
+    batchable: false
+  });
 }
 
 util.inherits(TransferFrame, FrameBase.AMQPFrame);

--- a/lib/sasl.js
+++ b/lib/sasl.js
@@ -2,6 +2,7 @@
 
 var debug = require('debug')('amqp10-Sasl'),
     builder = require('buffer-builder'),
+    _ = require('lodash'),
 
     constants = require('./constants'),
     codec = require('./codec'),
@@ -55,7 +56,7 @@ Sasl.prototype.headerReceived = function(header) {
 
 Sasl.prototype._processFrame = function(frame) {
   if (frame instanceof SaslFrames.SaslMechanisms) {
-    if (u.contains(frame.mechanisms, 'PLAIN')) {
+    if (_.contains(frame.mechanisms, 'PLAIN')) {
       debug('Sending ' + this.credentials.user + ':' + this.credentials.pass);
       var buf = new builder();
       buf.appendUInt8(0); // <nul>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "butils": "^0.1.0",
     "bl": "^0.9.4",
     "debug": "^2.0.0",
+    "lodash": "^3.3.0",
     "node-amqp-encoder": "^0.0.2",
     "node-int64": "^0.3.2",
     "readable-stream": "^1.0.32",


### PR DESCRIPTION
Lodash is a highly tested, and often used, library containing a number of
very useful methods some of which have been duplicated in this library's
utility class. This change introduced lodash as a dependency, and opts
for using its methods over the custom implementations. For starters, each
frame has been converted to using lodash.defaults.