### PR TITLE
refactor(disposition): reduced duplication, added error handling

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -180,29 +180,30 @@ AMQPClient.prototype.connect = function(url, cb) {
       debug('Link ' + l.name + ' detached');
       self.emit(AMQPClient.LinkDetached, l);
     });
+
     self._session.on(Session.DispositionReceived, function(details) {
       if (details.settled) {
         var err = null;
         if (details.state instanceof DeliveryStates.Rejected) {
           err = details.state.error;
         }
-        if (details.last) {
-          for (var msgid = details.first; msgid < details.last; ++msgid) {
-            if (self._unsettledSends[msgid]) {
-              self._unsettledSends[msgid](err, details.state);
-              self._unsettledSends[msgid] = undefined;
-            }
-          }
-        } else {
-          if (self._unsettledSends[details.first]) {
-            self._unsettledSends[details.first](err, details.state);
-            self._unsettledSends[details.first] = undefined;
+
+        var first = details.first;
+        var last = details.last || first;
+        for (var messageId = first; messageId <= last; ++messageId) {
+          if (self._unsettledSends[messageId]) {
+            self._unsettledSends[messageId](err, details.state);
+            delete self._unsettledSends[messageId];
+          } else {
+            debug('Invalid messageId: ' + messageId);
           }
         }
       }
     });
+
     self._session.begin(self.policy.sessionPolicy);
   });
+
   this._connection.on(Connection.Disconnected, function() {
     debug('Disconnected');
     self.emit(AMQPClient.ConnectionClosed);

--- a/lib/session.js
+++ b/lib/session.js
@@ -333,25 +333,23 @@ Session.prototype._processFrame = function(frame) {
           debug('Not yet processing "sender" Disposition frames');
         } else {
           var first = frame.first;
-          var last = frame.last;
+          var last = frame.last || first;
           var settled = frame.settled;
+
           if (settled) {
-            if (last) {
-              for (var msgid = first; msgid < last; ++msgid) {
-                if (this._transfersInFlight[msgid]) {
-                  var delta = Date.now() - this._transfersInFlight[msgid].sent;
-                  this._transfersInFlight[msgid] = undefined;
-                  debug('Message ' + msgid + ' settled in ' + delta + ' millis');
-                }
-              }
-            } else {
-              if (this._transfersInFlight[first]) {
-                var delta2 = Date.now() - this._transfersInFlight[first].sent;
-                this._transfersInFlight[first] = undefined;
-                debug('Message ' + first + ' settled in ' + delta2 + ' millis');
+            for (var messageId = first; messageId <= last; ++messageId) {
+              if (this._transfersInFlight[messageId]) {
+                var delta = Date.now() - this._transfersInFlight[messageId].sent;
+                delete this._transfersInFlight[messageId];
+                debug('Message ' + messageId + ' settled in ' + delta + ' ms');
+              } else {
+                debug('Invalid messageId: ' + messageId);
               }
             }
+          } else {
+            debug('Not settled, first: ' + first + ', last: ' + last);
           }
+
           this.emit(Session.DispositionReceived, {
             first: first,
             last: last,

--- a/lib/types/delivery_state.js
+++ b/lib/types/delivery_state.js
@@ -73,10 +73,13 @@ module.exports.Accepted = Accepted;
 
 function Rejected(options) {
   Rejected.super_.call(this, Rejected.Descriptor.code);
+
+  options = options || {};
   if (options instanceof AMQPError) {
     this.error = options;
   } else {
-    this.error = options.error;
+    // TODO: qpid sends back no error, what should this message be?
+    this.error = options.error || "rejected";
   }
 }
 


### PR DESCRIPTION
There was a certain amount of duplication in the disposition frame
handling which was easily consolidated. Also, testing against a QPID
server exposed some issues with rejected messages. I've left a comment
in there for future discussion about what should be returned in the
event that a rejection error is not provided. Note that a few debug
messages were temporarily added to help trace errors in the meantime
before a general debug cleanup occurs.