### PR TITLE
refactor(frame_reader): reduce complixity and enhance readability

### DIFF
--- a/lib/frames/frame_reader.js
+++ b/lib/frames/frame_reader.js
@@ -2,6 +2,9 @@
 
 var debug = require('debug')('amqp10-FrameReader'),
 
+    _ = require('lodash'),
+    util = require('util'),
+
     Attach = require('./attach_frame'),
     Begin = require('./begin_frame'),
     Close = require('./close_frame'),
@@ -21,159 +24,63 @@ var debug = require('debug')('amqp10-FrameReader'),
     DescribedType = require('../types/described_type'),
     M = require('../types/message');
 
-
-
-/**
- *
- * @constructor
- */
-function FrameReader() {
+function FrameReaderBase() {
+  this._registry = {};
 }
 
-
-/**
- * For now, just process performative headers.
- * @todo Need to process the payloads as well
- * @todo Cope with Non-AMQP frames
- *
- * @param buffer       Buffer containing the potential frame data.
- * @return {AMQPFrame} Frame with populated data, undefined if frame is incomplete.  Throws exception on unmatched frame.
- */
-FrameReader.prototype.read = function(buffer) {
-  if (buffer.length < 8) return undefined;
-
-  var size = buffer.slice(0, 4).readUInt32BE(0);
-  if (size > buffer.length) return undefined;
-
-  var sizeAndDoff = buffer.slice(0, 8);
-  buffer.consume(8);
-
-  var doff = sizeAndDoff[4];
-  var frameType = sizeAndDoff[5];
-  var xHeaderSize = (doff * 4) - 8;
-  var payloadSize = size - (doff * 4);
-  if (xHeaderSize > 0) {
-    var xHeaderBuf = buffer.slice(0, xHeaderSize);
-    buffer.consume(xHeaderSize);
-
-    // @todo Process x-header
-    debug('Read extended header [' + xHeaderBuf.toString('hex') + ']');
-  }
-
-  var payloadBuf = null;
-  if (payloadSize > 0) {
-    payloadBuf = buffer.slice(0, payloadSize);
-    buffer.consume(payloadSize);
-
-    if (frameType === constants.frameType.amqp) {
-      var channel = sizeAndDoff.readUInt16BE(6); // Bytes 6 & 7 are channel
-      var decoded = codec.decode(payloadBuf, 0);
-      if (!decoded) throw new exceptions.MalformedPayloadError('Unable to parse frame payload [' + payloadBuf.toString('hex') + ']');
-      if (!(decoded[0] instanceof DescribedType)) {
-        throw new exceptions.MalformedPayloadError('Expected DescribedType from AMQP Payload, but received ' + JSON.stringify(decoded[0]));
-      }
-      var describedType = decoded[0];
-      //debug('Rx on channel '+channel+': ' + JSON.stringify(describedType));
-      switch (describedType.descriptor.toString()) {
-        case Open.Descriptor.name.toString():
-        case Open.Descriptor.code.toString():
-          return new Open(describedType);
-
-        case Close.Descriptor.name.toString():
-        case Close.Descriptor.code.toString():
-          return new Close(describedType);
-
-        case Begin.Descriptor.name.toString():
-        case Begin.Descriptor.code.toString():
-          var beginFrame = new Begin(describedType);
-          beginFrame.channel = channel;
-          return beginFrame;
-
-        case End.Descriptor.name.toString():
-        case End.Descriptor.code.toString():
-          var endFrame = new End(describedType);
-          endFrame.channel = channel;
-          return endFrame;
-
-        case Attach.Descriptor.name.toString():
-        case Attach.Descriptor.code.toString():
-          var attachFrame = new Attach(describedType);
-          attachFrame.channel = channel;
-          return attachFrame;
-
-        case Detach.Descriptor.name.toString():
-        case Detach.Descriptor.code.toString():
-          var detachFrame = new Detach(describedType);
-          detachFrame.channel = channel;
-          return detachFrame;
-
-        case Flow.Descriptor.name.toString():
-        case Flow.Descriptor.code.toString():
-          var flowFrame = new Flow(describedType);
-          flowFrame.channel = channel;
-          return flowFrame;
-
-        case Transfer.Descriptor.name.toString():
-        case Transfer.Descriptor.code.toString():
-          var transferFrame = new Transfer(describedType);
-          transferFrame.channel = channel;
-          transferFrame.message = this._readMessage(payloadBuf.slice(decoded[1]));
-          return transferFrame;
-
-        case Disposition.Descriptor.name.toString():
-        case Disposition.Descriptor.code.toString():
-          var dispoFrame = new Disposition(describedType);
-          dispoFrame.channel = channel;
-          return dispoFrame;
-
-        default:
-          debug('Failed to match descriptor ' + describedType.descriptor.toString());
-          break;
-      }
-      throw new exceptions.MalformedPayloadError('Failed to match AMQP performative ' + describedType.descriptor.toString());
-    } else if (frameType === constants.frameType.sasl) {
-      var saslPayload = codec.decode(payloadBuf, 0);
-      if (!(saslPayload[0] instanceof DescribedType)) {
-        throw new exceptions.MalformedPayloadError('Expected DescribedType from AMQP Payload, but received ' + JSON.stringify(saslPayload[0]));
-      }
-
-      var saslType = saslPayload[0];
-      debug('Rx SASL Frame: ' + JSON.stringify(saslType));
-      switch (saslType.descriptor.toString()) {
-        case Sasl.SaslInit.Descriptor.name.toString():
-        case Sasl.SaslInit.Descriptor.code.toString():
-          return new Sasl.SaslInit(saslType);
-
-        case Sasl.SaslMechanisms.Descriptor.name.toString():
-        case Sasl.SaslMechanisms.Descriptor.code.toString():
-          return new Sasl.SaslMechanisms(saslType);
-
-        case Sasl.SaslChallenge.Descriptor.name.toString():
-        case Sasl.SaslChallenge.Descriptor.code.toString():
-          return new Sasl.SaslChallenge(saslType);
-
-        case Sasl.SaslResponse.Descriptor.name.toString():
-        case Sasl.SaslResponse.Descriptor.code.toString():
-          return new Sasl.SaslResponse(saslType);
-
-        case Sasl.SaslOutcome.Descriptor.name.toString():
-        case Sasl.SaslOutcome.Descriptor.code.toString():
-          return new Sasl.SaslOutcome(saslType);
-
-        default:
-          debug('Failed to match SASL descriptor ' + saslType.descriptor.toString());
-      }
-      throw new exceptions.MalformedPayloadError('Failed to match SASL Frame ' + saslType.descriptor.toString());
-    } else {
-      throw new exceptions.NotImplementedError("We don't handle non-(AMQP|SASL) frames yet.");
-    }
-
-    throw new exceptions.MalformedPayloadError('Failed to match ' + (payloadBuf ? payloadBuf.toString('hex') : 'null'));
-  } else {
-    debug('Heartbeat frame: ' + sizeAndDoff.toString('hex'));
-  }
+FrameReaderBase.prototype._registerFrameType = function(FrameType) {
+  this._registry[FrameType.Descriptor.code.toString()] = FrameType;
+  this._registry[FrameType.Descriptor.name.toString()] = FrameType;
 };
 
+FrameReaderBase.prototype._readFrame = function(channel, describedType, buffer) {
+  var descriptor = describedType.descriptor.toString();
+  if (!_.has(this._registry, descriptor)) {
+    debug('Failed to match descriptor ' + descriptor);
+    throw new exceptions.MalformedPayloadError('Failed to match AMQP performative ' + descriptor);
+  }
+
+  return new this._registry[descriptor](describedType);
+};
+
+function AmqpFrameReader() {
+  AmqpFrameReader.super_.call(this);
+  this._registerFrameType(Open);
+  this._registerFrameType(Close);
+  this._registerFrameType(Begin);
+  this._registerFrameType(End);
+  this._registerFrameType(Attach);
+  this._registerFrameType(Detach);
+  this._registerFrameType(Flow);
+  this._registerFrameType(Transfer);
+  this._registerFrameType(Disposition);
+}
+util.inherits(AmqpFrameReader, FrameReaderBase);
+
+AmqpFrameReader.prototype.read = function(channel, describedType, buffer) {
+  //debug('Rx on channel '+channel+': ' + JSON.stringify(describedType));
+  var frame = this._readFrame(channel, describedType, buffer);
+  frame.channel = channel;
+  if (frame instanceof Transfer)
+    frame.message = readAmqpMessage(buffer);
+  return frame;
+};
+
+function SaslFrameReader() {
+  SaslFrameReader.super_.call(this);
+  this._registerFrameType(Sasl.SaslInit);
+  this._registerFrameType(Sasl.SaslMechanisms);
+  this._registerFrameType(Sasl.SaslChallenge);
+  this._registerFrameType(Sasl.SaslResponse);
+  this._registerFrameType(Sasl.SaslOutcome);
+}
+util.inherits(SaslFrameReader, FrameReaderBase);
+
+SaslFrameReader.prototype.read = function(channel, describedType, buffer) {
+  // NOTE: channel is ignored for SASL frames
+  debug('Rx SASL Frame: ' + JSON.stringify(describedType));
+  return this._readFrame(channel, describedType, buffer);
+};
 
 /**
  * An AMQP Message is composed of:
@@ -186,11 +93,11 @@ FrameReader.prototype.read = function(buffer) {
  * * Body: One or more data sections, one or more amqp-sequence sections, or one amqp-value section
  * * Zero or one footer
  *
- * @param {Buffer} messageBuf       Message buffer to decode
+ * @param {Buffer} buffer          Message buffer to decode
  * @return {Message}               Complete message object decoded from buffer
  * @private
  */
-FrameReader.prototype._readMessage = function(messageBuf) {
+function readAmqpMessage(buffer) {
   var message = new M.Message();
   var body = [];
   var curIdx = 0;
@@ -200,10 +107,10 @@ FrameReader.prototype._readMessage = function(messageBuf) {
   };
   var isData = function(x) { return x instanceof M.Data; };
   var isSequence = function(x) { return x instanceof M.AMQPSequence; };
-  while (curIdx < messageBuf.length) {
-    var decoded = codec.decode(messageBuf, curIdx);
+  while (curIdx < buffer.length) {
+    var decoded = codec.decode(buffer, curIdx);
     if (!decoded) throw new exceptions.MalformedPayloadError(
-        'Unable to decode bytes from message body: ' + messageBuf.slice(curIdx).toString('hex'));
+        'Unable to decode bytes from message body: ' + buffer.slice(curIdx).toString('hex'));
     curIdx += decoded[1];
     var matched = false;
     for (var fieldName in possibleFields) {
@@ -236,6 +143,77 @@ FrameReader.prototype._readMessage = function(messageBuf) {
   message.body = body.map(function(x) { return x.getValue(); });
 
   return message;
+}
+
+
+
+/**
+ *
+ * @constructor
+ */
+function FrameReader() {
+  this._frameReaders = {};
+  this._frameReaders[constants.frameType.amqp] = new AmqpFrameReader();
+  this._frameReaders[constants.frameType.sasl] = new SaslFrameReader();
+}
+
+/**
+ * For now, just process performative headers.
+ * @todo Need to process the payloads as well
+ * @todo Cope with Non-AMQP frames
+ *
+ * @param buffer       Buffer containing the potential frame data.
+ * @return {AMQPFrame} Frame with populated data, undefined if frame is incomplete.  Throws exception on unmatched frame.
+ */
+FrameReader.prototype.read = function(buffer) {
+  if (buffer.length < 8) return undefined;
+
+  var size = buffer.slice(0, 4).readUInt32BE(0);
+  if (size > buffer.length) return undefined;
+
+  var sizeAndDoff = buffer.slice(0, 8);
+  buffer.consume(8);
+
+  var doff = sizeAndDoff[4];
+  var frameType = sizeAndDoff[5];
+  if (!_.has(this._frameReaders, frameType)) {
+    throw new exceptions.NotImplementedError("Unsupported frame type: " + frameType);
+  }
+
+  var payloadSize = size - (doff * 4);
+  if (payloadSize <= 0) {
+    // TODO: this is probably a heartbeat frame, but what if its not?
+    debug('Heartbeat frame: ' + sizeAndDoff.toString('hex'));
+    return;
+  }
+
+  var xHeaderSize = (doff * 4) - 8;
+  if (xHeaderSize > 0) {
+    var xHeaderBuf = buffer.slice(0, xHeaderSize);
+    buffer.consume(xHeaderSize);
+
+    // @todo Process x-header
+    debug('Read extended header [' + xHeaderBuf.toString('hex') + ']');
+  }
+
+  // read payload
+  var payloadBuffer = buffer.slice(0, payloadSize);
+  buffer.consume(payloadSize);
+
+  // decode payload
+  var decodedPayload = codec.decode(payloadBuffer, 0);
+  if (!decodedPayload) {
+    throw new exceptions.MalformedPayloadError('Unable to parse frame payload [' + payloadBuffer.toString('hex') + ']');
+  }
+
+  if (!(decodedPayload[0] instanceof DescribedType)) {
+    throw new exceptions.MalformedPayloadError('Expected DescribedType from AMQP Payload, but received ' + JSON.stringify(decodedPayload[0]));
+  }
+
+  // read frame
+  var channel = sizeAndDoff.readUInt16BE(6); // Bytes 6 & 7 are channel
+  var messageBuffer = payloadBuffer.slice(decodedPayload[1]);
+  return this._frameReaders[frameType].read(channel, decodedPayload[0], messageBuffer);
 };
 
 module.exports = new FrameReader();


### PR DESCRIPTION
FrameReader used to be a large collection of switch statements. This
change reduces that complexity by splitting into the concept of AMQP
and SASL frame internal reader classes. A number of other readability
cleanups occurred including: unrolling a number of if statements to
fail early, as well as registration of Readers.

**NOTE:** I'd like to further discuss this PR, because while the readability of having multiple internal FrameReaders is nice, this can be optimized even more to create a single registry in the FrameReader class encompassing all frame types we accept. It would reduce readability imho, but probably improve performance. Furthermore, if we can agree on what all *_frame.js files should look like, we can automate the building of the frame registry.
