### PR TITLE
perf(tests): dramatically speed up test runs

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -353,8 +353,8 @@ Connection.prototype._nextChannel = function() {
 };
 
 Connection.prototype._processError = function(err) {
-  console.warn('Error from socket: ' + err);
-  // TODO: Cleanly close on error
+  debug('Error from socket: ' + err);
+  // @todo: Cleanly close on error
   this._terminate();
 };
 

--- a/test/test_amqpclient.js
+++ b/test/test_amqpclient.js
@@ -89,6 +89,7 @@ function MakeMockClient(c, s) {
     c._created++;
     return c;
   };
+
   client._newSession = function(conn) {
     for (var lname in s._mockLinks) {
       var l = s._mockLinks[lname];
@@ -98,6 +99,7 @@ function MakeMockClient(c, s) {
     s._created++;
     return s;
   };
+
   client._clearState = function() {
     var connEvts = [Connection.Connected, Connection.Disconnected];
     var sessEvts = [Session.Mapped, Session.Unmapped, Session.ErrorReceived, Session.LinkAttached, Session.LinkDetached, Session.DispositionReceived];
@@ -113,6 +115,7 @@ function MakeMockClient(c, s) {
       EventEmitter.listenerCount(s, e).should.eql(0);
     }
   };
+
   return client;
 }
 
@@ -131,10 +134,12 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       client.connect(addr, function(err, _client) {
         (err === null).should.be.true;
         c._created.should.eql(1);
@@ -151,10 +156,11 @@ describe('AMQPClient', function() {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 100
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -166,30 +172,35 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
       client.send({ my: 'message' }, addr + queue, function(err) {
         (err === null).should.be.true;
         c._created.should.eql(1);
@@ -205,14 +216,16 @@ describe('AMQPClient', function() {
         done();
       });
     });
+
     it('should wait for capacity before sending', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 0
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 0
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -224,35 +237,41 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         client._pendingSends[_l.name].length.should.eql(1);
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
-        setTimeout(function() {
+        process.nextTick(function() {
           _l.capacity = 100;
           _l.emit(Link.CreditChange, _l);
-        }, 100);
+        });
+
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
       client.send({ my: 'message' }, addr + queue, function(err) {
         (err === null).should.be.true;
         c._created.should.eql(1);
@@ -268,14 +287,16 @@ describe('AMQPClient', function() {
         done();
       });
     });
+
     it('should only create a single connection, session, link for multiple sends', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 100
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -287,34 +308,41 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
+      var tmpFunction = function () {};
       for (var idx = 0; idx < 5; idx++) {
-        client.send({my: 'message'}, addr + queue, function() {});
+        client.send({my: 'message'}, addr + queue, tmpFunction);
       }
-      setTimeout(function() {
+
+      process.nextTick(function() {
         c._created.should.eql(1);
         s._created.should.eql(1);
         l._created.should.eql(1);
@@ -325,16 +353,18 @@ describe('AMQPClient', function() {
         called.sendMessage.should.eql(5);
         l.messages.length.should.eql(5);
         done();
-      }, 100);
+      });
     });
+
     it('should re-establish send link on detach, on next send', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 100
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -346,41 +376,47 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
         if (called.attachLink === 1) {
-          setTimeout(function() {
+          process.nextTick(function() {
             _l.emit(Link.Detached);
             _s.emit(Session.LinkDetached, _l);
-          }, 100);
+          });
         }
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
       client.send({my: 'message'}, addr + queue, function() {});
-      setTimeout(function() {
+      process.nextTick(function() {
         client.send({my: 'message'}, addr + queue, function() {});
-      }, 150);
-      setTimeout(function() {
+      });
+
+      process.nextTick(function() {
         c._created.should.eql(1);
         s._created.should.eql(1);
         l._created.should.eql(2);
@@ -391,16 +427,18 @@ describe('AMQPClient', function() {
         called.sendMessage.should.eql(2);
         l.messages.length.should.eql(1);
         done();
-      }, 400);
+      });
     });
+
     it('should re-establish connection on disconnect, on next send', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 100
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -412,40 +450,46 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
         if (called.attachLink === 1) {
-          setTimeout(function() {
+          process.nextTick(function() {
             c.emit(Connection.Disconnected);
-          }, 100);
+          });
         }
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
       client.send({my: 'message'}, addr + queue, function() {});
-      setTimeout(function() {
+      process.nextTick(function() {
         client.send({my: 'message'}, addr + queue, function() {});
-      }, 150);
-      setTimeout(function() {
+      });
+
+      process.nextTick(function() {
         c._created.should.eql(2);
         s._created.should.eql(2);
         l._created.should.eql(2);
@@ -456,16 +500,18 @@ describe('AMQPClient', function() {
         called.sendMessage.should.eql(2);
         l.messages.length.should.eql(1);
         done();
-      }, 400);
+      });
     });
+
     it('should re-establish connection on disconnect, if send is pending', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_TX',
-                isSender: true,
-                capacity: 0
+        name: 'queue_TX',
+        isSender: true,
+        capacity: 0
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -477,42 +523,49 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         client._pendingSends[_l.name].length.should.eql(1);
         _policy.options.target.should.eql({ address: queue });
         _policy.options.role.should.eql(constants.linkRole.sender);
         if (called.attachLink === 1) {
-          setTimeout(function() {
+          process.nextTick(function() {
             c.emit(Connection.Disconnected);
-          }, 50);
+          });
         } else {
-          setTimeout(function() {
+          process.nextTick(function() {
             _l.capacity = 100;
             _l.emit(Link.CreditChange, _l);
-          }, 100);
+          });
         }
         _s.emit(Session.LinkAttached, _l);
       });
+
       l.on('canSend-called', function() {
         called.canSend++;
       });
+
       l.on('sendMessage-called', function(_l, id, msg, opts) {
         called.sendMessage++;
-        setTimeout(function() {
+        process.nextTick(function() {
           s.emit(Session.DispositionReceived, {
             settled: true,
             state: { },
             first: id,
             last: null
           });
-        }, 50);
+        });
       });
+
       client.send({my: 'message'}, addr + queue, function() {});
+
+      // NOTE: reverted to setTimeout, but nextTick -should- work...
       setTimeout(function() {
         c._created.should.eql(2);
         s._created.should.eql(2);
@@ -524,7 +577,7 @@ describe('AMQPClient', function() {
         called.sendMessage.should.eql(1);
         l.messages.length.should.eql(1);
         done();
-      }, 400);
+      }, 1);
     });
   });
 
@@ -533,10 +586,11 @@ describe('AMQPClient', function() {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_RX',
-                isSender: false,
-                capacity: 100
+        name: 'queue_RX',
+        isSender: false,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -548,19 +602,21 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.source.should.eql({ address: queue, filter: undefined });
         _policy.options.role.should.eql(constants.linkRole.receiver);
         _s.emit(Session.LinkAttached, _l);
       });
-      client.receive(addr + queue, function(err, payload, annotations) {
-      });
-      setTimeout(function() {
+
+      client.receive(addr + queue, function(err, payload, annotations) {});
+      process.nextTick(function() {
         c._created.should.eql(1);
         s._created.should.eql(1);
         l._created.should.eql(1);
@@ -568,8 +624,9 @@ describe('AMQPClient', function() {
         called.begin.should.eql(1);
         called.attachLink.should.eql(1);
         done();
-      }, 50);
+      });
     });
+
     it('should only create a single connection, session, multiple links for multiple receives', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
@@ -578,13 +635,16 @@ describe('AMQPClient', function() {
         isSender: false,
         capacity: 100
       });
+
       var l2 = new MockLink(s, {
         name: 'queue2_RX',
         isSender: false,
         capacity: 100
       });
+
       s._addMockLink(l1);
       s._addMockLink(l2);
+
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
       var called = { open: 0, begin: 0, attachLink: 0 };
@@ -594,18 +654,21 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.role.should.eql(constants.linkRole.receiver);
         _s.emit(Session.LinkAttached, _l);
       });
+
       client.receive(addr + 'queue1', function(err, payload, annotations) {});
       client.receive(addr + 'queue2', function(err, payload, annotations) {});
-      setTimeout(function() {
+      process.nextTick(function() {
         c._created.should.eql(1);
         s._created.should.eql(1);
         l1._created.should.eql(1);
@@ -614,16 +677,18 @@ describe('AMQPClient', function() {
         called.begin.should.eql(1);
         called.attachLink.should.eql(2);
         done();
-      }, 100);
+      });
     });
+
     it('should re-establish receive link on detach, automatically', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_RX',
-                isSender: false,
-                capacity: 100
+        name: 'queue_RX',
+        isSender: false,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -635,24 +700,27 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.source.should.eql({ address: queue, filter: undefined });
         _policy.options.role.should.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
-          setTimeout(function() {
+          process.nextTick(function() {
             _l.emit(Link.Detached);
             _s.emit(Session.LinkDetached, _l);
-          }, 50);
+          });
         }
         _s.emit(Session.LinkAttached, _l);
       });
+
       client.receive(addr + queue, function() {});
-      setTimeout(function() {
+      process.nextTick(function() {
         c._created.should.eql(1);
         s._created.should.eql(1);
         l._created.should.eql(2);
@@ -660,16 +728,18 @@ describe('AMQPClient', function() {
         called.begin.should.eql(1);
         called.attachLink.should.eql(2);
         done();
-      }, 400);
+      });
     });
+
     it('should re-establish connection on disconnect, automatically', function(done) {
       var c = new MockConnection();
       var s = new MockSession(c);
       var l = new MockLink(s, {
-                name: 'queue_RX',
-                isSender: false,
-                capacity: 100
+        name: 'queue_RX',
+        isSender: false,
+        capacity: 100
       });
+
       s._addMockLink(l);
       var client = new MakeMockClient(c, s);
       var addr = 'amqp://localhost/';
@@ -681,23 +751,27 @@ describe('AMQPClient', function() {
         called.open++;
         _c.emit(Connection.Connected, _c);
       });
+
       s.on('begin-called', function(_s, _policy) {
         called.begin++;
         _s.emit(Session.Mapped, _s);
       });
+
       s.on('attachLink-called', function(_s, _policy, _l) {
         called.attachLink++;
         _policy.options.source.should.eql({ address: queue, filter: undefined });
         _policy.options.role.should.eql(constants.linkRole.receiver);
         if (called.attachLink === 1) {
-          setTimeout(function() {
+          process.nextTick(function() {
             c.emit(Connection.Disconnected);
-          }, 100);
+          });
         }
+
         _s.emit(Session.LinkAttached, _l);
       });
+
       client.receive(addr + queue, function() {});
-      setTimeout(function() {
+      process.nextTick(function() {
         c._created.should.eql(2);
         s._created.should.eql(2);
         l._created.should.eql(2);
@@ -705,7 +779,7 @@ describe('AMQPClient', function() {
         called.begin.should.eql(2);
         called.attachLink.should.eql(2);
         done();
-      }, 400);
+      });
     });
   });
 });

--- a/test/test_codec.js
+++ b/test/test_codec.js
@@ -131,7 +131,6 @@ describe('Codec', function() {
         0x13,
         builder.prototype.appendString, 'Rafael H. Schloming',
         0x40]);
-      console.log('Composite type: ' + buffer.toString('hex'));
       var actual = codec.decode(newBuffer(buffer));
       actual[0].should.eql(new DescribedType(new AMQPSymbol('example:book:list'),
           [

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -2,7 +2,10 @@
 
 var builder = require('buffer-builder'),
     BufferList = require('bl'),
-    should = require('should');
+    should = require('should'),
+    _ = require('lodash');
+
+    var util = require('util');
 
 function buildBuffer(contents) {
   var bufb = new builder();
@@ -52,3 +55,17 @@ function shouldBufEql(expected, actual, msg) {
 }
 
 module.exports.shouldBufEql = shouldBufEql;
+
+module.exports.assertTransitions = function(expectedTransitions, callback) {
+  var actualTransitions = [];
+  return function(event, oldState, newState) {
+    if (_.isEmpty(actualTransitions)) actualTransitions.push(oldState);
+    actualTransitions.push(newState);
+
+    if (_.isEqual(actualTransitions, expectedTransitions)) {
+      callback(actualTransitions);
+    }
+
+    // @todo: should we display incorrect states?
+  };
+};


### PR DESCRIPTION
There were a number of cases where setTimeout was being used
inappropriately throughout our test suites. This includes a
refactoring for asserting state transitions, as well as outright
removal of setTimeout for the AMQPClient tests.