### PR TITLE
refactor(test-send-buffers): streamline outgoing buffers for tests

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -329,10 +329,8 @@ Connection.prototype.close = function() {
 };
 
 Connection.prototype.sendFrame = function(frame) {
-  var frameBuf = frame.outgoing();
-  debug('Sending frame: ' + frame.constructor.name + ': ' + JSON.stringify(frame) + ': ' + frameBuf.toString('hex'));
   this._lastOutgoing = Date.now();
-  this.client.write(frameBuf);
+  frame.write(this.client);
 };
 
 Connection.prototype.associateSession = function(session) {

--- a/lib/frames/begin_frame.js
+++ b/lib/frames/begin_frame.js
@@ -120,8 +120,10 @@ BeginFrame.prototype._getPerformative = function() {
     offeredCapabilities: self.offeredCapabilities, /* symbol */
     desiredCapabilities: self.desiredCapabilities, /* symbol */
     properties: self.properties,
-    encodeOrdering: ['remoteChannel', 'nextOutgoingId', 'incomingWindow', 'outgoingWindow', 'handleMax', 'offeredCapabilities',
-      'desiredCapabilities', 'properties']
+    encodeOrdering: [
+      'remoteChannel', 'nextOutgoingId', 'incomingWindow', 'outgoingWindow',
+      'handleMax', 'offeredCapabilities', 'desiredCapabilities', 'properties'
+    ]
   });
 };
 

--- a/lib/frames/frame.js
+++ b/lib/frames/frame.js
@@ -64,37 +64,28 @@ Frame.prototype._writePayload = function(bufBuilder, options) {
   throw new exceptions.NotImplementedError('Subclass must override _writePayload');
 };
 
-
-/**
- * Populate the internal buffer with contents built based on the options.  SIZE and DOFF will be inferred
- * based on the options given.
- *
- * @private
- */
-Frame.prototype.outgoing = function(options) {
+Frame.prototype.write = function(outStream, options) {
   var isAMQP = this.frameType === constants.frameType.amqp;
   var bufBuilder = new builder();
   bufBuilder.appendUInt32BE(0); // Size placeholder
+
   // DOFF placeholder(8) | type(8) | type-specific(16)
   var doffHeader = ((this.frameType & 0xFF) << 16) | (this._getTypeSpecificHeader() & 0xFFFF);
   bufBuilder.appendUInt32BE(doffHeader);
   var extHeaderSize = this._writeExtendedHeader(bufBuilder, options);
   this._writePayload(bufBuilder, options);
-  var buf = bufBuilder.get();
+
+  var buffer = bufBuilder.get();
   var headerSize = 8 + extHeaderSize;
-  var size = buf.length;
+  var size = buffer.length;
   var doff = headerSize / 4;
+
   // Now that we know size and DOFF, fill in the blanks.
-  buf.writeUInt32BE(size, 0);
-  buf.writeUInt8(doff, 4);
+  buffer.writeUInt32BE(size, 0);
+  buffer.writeUInt8(doff, 4);
 
-  //debug('Built frame ['+buf.toString('hex')+'] of length '+size);
-  return buf;
-};
-
-Frame.prototype.write = function(outStream) {
-  var outbuf = this.outgoing();
-  outStream.write(outbuf);
+  debug('Sending frame: ' + this.constructor.name + ': ' + JSON.stringify(buffer) + ': ' + buffer.toString('hex'));
+  outStream.write(buffer);
 };
 
 module.exports.Frame = Frame;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "mocha": "^2.1.0",
     "chai": "^2.0.0",
     "jshint": "^2.6.0",
-    "istanbul": "^0.3.6"
+    "istanbul": "^0.3.6",
+    "stream-buffers": "2.1.0"
   },
   "scripts": {},
   "author": {

--- a/test/test_connection.js
+++ b/test/test_connection.js
@@ -2,7 +2,6 @@
 
 var debug = require('debug')('amqp10-test_connection'),
     should = require('should'),
-    builder = require('buffer-builder'),
 
     constants = require('../lib/constants'),
 
@@ -26,16 +25,6 @@ var debug = require('debug')('amqp10-test_connection'),
     tu = require('./testing_utils');
 
 PolicyBase.connectPolicy.options.containerId = 'test';
-
-function openBuf() {
-  var open = new OpenFrame(PolicyBase.connectPolicy.options);
-  return open.outgoing();
-}
-
-function closeBuf(err) {
-  var close = new CloseFrame(err);
-  return close.outgoing();
-}
 
 describe('Connection', function() {
   describe('#_open()', function() {
@@ -149,10 +138,10 @@ describe('Connection', function() {
       server = new MockServer();
       server.setSequence([
         constants.amqpVersion,
-        openBuf()
+        new OpenFrame(PolicyBase.connectPolicy.options)
       ], [
         constants.amqpVersion,
-        closeBuf()
+        new CloseFrame()
       ]);
 
       var connection = new Connection(PolicyBase.connectPolicy);
@@ -170,10 +159,10 @@ describe('Connection', function() {
       server = new MockServer();
       server.setSequence([
         constants.amqpVersion,
-        openBuf()
+        new OpenFrame(PolicyBase.connectPolicy.options)
       ], [
         [ true, constants.amqpVersion ],
-        closeBuf()
+        new CloseFrame()
       ]);
 
       var connection = new Connection(PolicyBase.connectPolicy);
@@ -220,12 +209,12 @@ describe('Connection', function() {
       server = new MockServer();
       server.setSequence([
         constants.amqpVersion,
-        openBuf(),
-        closeBuf()
+        new OpenFrame(PolicyBase.connectPolicy.options),
+        new CloseFrame()
       ], [
         constants.amqpVersion,
-        openBuf(),
-        [ true, closeBuf(new AMQPError(AMQPError.ConnectionForced, 'test')) ]
+        new OpenFrame(PolicyBase.connectPolicy.options),
+        [ true, new CloseFrame(new AMQPError(AMQPError.ConnectionForced, 'test')) ]
       ]);
 
       var connection = new Connection(PolicyBase.connectPolicy);
@@ -242,12 +231,12 @@ describe('Connection', function() {
       server = new MockServer();
       server.setSequence([
         constants.amqpVersion,
-        openBuf(),
-        closeBuf()
+        new OpenFrame(PolicyBase.connectPolicy.options),
+        new CloseFrame()
       ], [
         constants.amqpVersion,
-        openBuf(),
-        [ true, closeBuf(new AMQPError(AMQPError.ConnectionForced, 'test')) ]
+        new OpenFrame(PolicyBase.connectPolicy.options),
+        [ true, new CloseFrame(new AMQPError(AMQPError.ConnectionForced, 'test')) ]
       ]);
 
       var connection = new Connection(PolicyBase.connectPolicy);

--- a/test/test_frame_encodings.js
+++ b/test/test_frame_encodings.js
@@ -28,235 +28,227 @@ var Int64 = require('node-int64'),
     tu = require('./testing_utils');
 
 describe('OpenFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode performative correctly', function() {
-      var open = new OpenFrame({ containerId: 'test', hostname: 'localhost' });
-      var actual = open.outgoing();
-      var expected = tu.buildBuffer([
-        0x00, 0x00, 0x00, 0x46,
-        0x02, 0x00, 0x00, 0x00,
-        0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x10,
-        0xc0, 0x32, 0x0a, // list
-        0xa1, 4, builder.prototype.appendString, 'test',
-        0xa1, 9, builder.prototype.appendString, 'localhost',
-        0x70, builder.prototype.appendUInt32BE, constants.defaultMaxFrameSize,
-        0x60, builder.prototype.appendUInt16BE, constants.defaultChannelMax,
-        0x70, builder.prototype.appendUInt32BE, constants.defaultIdleTimeout,
-        0xa3, 5, builder.prototype.appendString, constants.defaultOutgoingLocales,
-        0xa3, 5, builder.prototype.appendString, constants.defaultIncomingLocales,
-        0x40, 0x40, 0xc1, 0x01, 0x00
-      ]);
-      tu.shouldBufEql(expected, actual);
-    });
+  it('should encode performative correctly', function() {
+    var open = new OpenFrame({ containerId: 'test', hostname: 'localhost' });
+    var actual = tu.convertFrameToBuffer(open);
+    var expected = tu.buildBuffer([
+      0x00, 0x00, 0x00, 0x46,
+      0x02, 0x00, 0x00, 0x00,
+      0x00,
+      0x80, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x10,
+      0xc0, 0x32, 0x0a, // list
+      0xa1, 4, builder.prototype.appendString, 'test',
+      0xa1, 9, builder.prototype.appendString, 'localhost',
+      0x70, builder.prototype.appendUInt32BE, constants.defaultMaxFrameSize,
+      0x60, builder.prototype.appendUInt16BE, constants.defaultChannelMax,
+      0x70, builder.prototype.appendUInt32BE, constants.defaultIdleTimeout,
+      0xa3, 5, builder.prototype.appendString, constants.defaultOutgoingLocales,
+      0xa3, 5, builder.prototype.appendString, constants.defaultIncomingLocales,
+      0x40, 0x40, 0xc1, 0x01, 0x00
+    ]);
+
+    tu.shouldBufEql(expected, actual);
   });
 });
 
 describe('BeginFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode performative correctly', function() {
-      var begin = new BeginFrame({ nextOutgoingId: 1, incomingWindow: 100, outgoingWindow: 100 });
-      begin.channel = 1;
-      var actual = begin.outgoing();
-      var expected = tu.buildBuffer([
-        0x00, 0x00, 0x00, 0x26,
-        0x02, 0x00, 0x00, 0x01,
-        0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x11,
-        0xc0, 0x12, 0x08, // list
-        0x40,
-        0x52, 0x01,
-        0x52, 0x64,
-        0x52, 0x64,
-        0x70, builder.prototype.appendUInt32BE, constants.defaultHandleMax,
-        0x40, 0x40, 0xc1, 0x01, 0x00
-      ]);
-      tu.shouldBufEql(expected, actual);
-    });
+  it('should encode performative correctly', function() {
+    var begin = new BeginFrame({ nextOutgoingId: 1, incomingWindow: 100, outgoingWindow: 100 });
+    begin.channel = 1;
+    var actual = tu.convertFrameToBuffer(begin);
+    var expected = tu.buildBuffer([
+      0x00, 0x00, 0x00, 0x26,
+      0x02, 0x00, 0x00, 0x01,
+      0x00,
+      0x80, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x11,
+      0xc0, 0x12, 0x08, // list
+      0x40,
+      0x52, 0x01,
+      0x52, 0x64,
+      0x52, 0x64,
+      0x70, builder.prototype.appendUInt32BE, constants.defaultHandleMax,
+      0x40, 0x40, 0xc1, 0x01, 0x00
+    ]);
+
+    tu.shouldBufEql(expected, actual);
   });
 });
 
 describe('AttachFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode performative correctly', function() {
-      var attach = new AttachFrame({
-        name: 'test',
-        handle: 1,
-        role: constants.linkRole.sender,
-        source: new Source({ address: null, dynamic: true }),
-        target: new Target({ address: 'testtgt' }),
-        initialDeliveryCount: 1 });
-      attach.channel = 1;
-      var actual = attach.outgoing();
-      var sourceSize = 1 + 1 + 1 + 13 + 1 + 1 + 3 + 1 + 3 + 1 + 1 + 1;
-      var targetSize = 1 + 9 + 1 + 13 + 1 + 1 + 3 + 1;
-      var listSize = 1 + 6 + 2 + 1 + 2 + 2 + 10 + 2 + sourceSize + 10 + 2 + targetSize + 3 + 1 + 2 + 1 + 1 + 1 + 3;
-      var listCount = 14;
-      var frameSize = 8 + 1 + 9 + 2 + listSize;
-      var expected = tu.buildBuffer([
-        0x00, 0x00, 0x00, frameSize,
-        0x02, 0x00, 0x00, 0x01,
-        0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x12,
-        0xc0, listSize, listCount,
-        0xA1, 4, builder.prototype.appendString, 'test',
-        0x52, 1, // handle
-        0x42, // role=sender
-        0x50, 2, // sender-settle-mode=mixed
-        0x50, 0, // rcv-settle-mode=first
-        0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x28, // source
-        0xc0, sourceSize, 11,
-        0x40,
-        0x43,
-        0xA3, 11, builder.prototype.appendString, 'session-end',
-        0x43,
-        0x41,
-        0xc1, 1, 0,
-        0x40,
-        0xc1, 1, 0,
-        0x40,
-        0x40,
-        0x40,
-        0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x29, // target
-        0xc0, targetSize, 7,
-        0xA1, 7, builder.prototype.appendString, 'testtgt',
-        0x43,
-        0xA3, 11, builder.prototype.appendString, 'session-end',
-        0x43,
-        0x42,
-        0xc1, 1, 0,
-        0x40,
-        0xc1, 1, 0,
-        0x42,
-        0x52, 1,
-        0x44,
-        0x40,
-        0x40,
-        0xc1, 1, 0
-      ]);
-      tu.shouldBufEql(expected, actual);
-    });
+  it('should encode performative correctly', function() {
+    var attach = new AttachFrame({
+      name: 'test',
+      handle: 1,
+      role: constants.linkRole.sender,
+      source: new Source({ address: null, dynamic: true }),
+      target: new Target({ address: 'testtgt' }),
+      initialDeliveryCount: 1 });
+    attach.channel = 1;
+    var actual = tu.convertFrameToBuffer(attach);
+    var sourceSize = 1 + 1 + 1 + 13 + 1 + 1 + 3 + 1 + 3 + 1 + 1 + 1;
+    var targetSize = 1 + 9 + 1 + 13 + 1 + 1 + 3 + 1;
+    var listSize = 1 + 6 + 2 + 1 + 2 + 2 + 10 + 2 + sourceSize + 10 + 2 + targetSize + 3 + 1 + 2 + 1 + 1 + 1 + 3;
+    var listCount = 14;
+    var frameSize = 8 + 1 + 9 + 2 + listSize;
+    var expected = tu.buildBuffer([
+      0x00, 0x00, 0x00, frameSize,
+      0x02, 0x00, 0x00, 0x01,
+      0x00,
+      0x80, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x12,
+      0xc0, listSize, listCount,
+      0xA1, 4, builder.prototype.appendString, 'test',
+      0x52, 1, // handle
+      0x42, // role=sender
+      0x50, 2, // sender-settle-mode=mixed
+      0x50, 0, // rcv-settle-mode=first
+      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x28, // source
+      0xc0, sourceSize, 11,
+      0x40,
+      0x43,
+      0xA3, 11, builder.prototype.appendString, 'session-end',
+      0x43,
+      0x41,
+      0xc1, 1, 0,
+      0x40,
+      0xc1, 1, 0,
+      0x40,
+      0x40,
+      0x40,
+      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x29, // target
+      0xc0, targetSize, 7,
+      0xA1, 7, builder.prototype.appendString, 'testtgt',
+      0x43,
+      0xA3, 11, builder.prototype.appendString, 'session-end',
+      0x43,
+      0x42,
+      0xc1, 1, 0,
+      0x40,
+      0xc1, 1, 0,
+      0x42,
+      0x52, 1,
+      0x44,
+      0x40,
+      0x40,
+      0xc1, 1, 0
+    ]);
+
+    tu.shouldBufEql(expected, actual);
   });
 });
 
 describe('FlowFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode performative correctly', function() {
-      var flow = new FlowFrame({
-        nextIncomingId: 1,
-        incomingWindow: 100,
-        nextOutgoingId: 1,
-        outgoingWindow: 100,
-        handle: 1,
-        deliveryCount: 2,
-        linkCredit: 100,
-        available: 0,
-        drain: false,
-        echo: true
-      });
-      flow.channel = 1;
-      var actual = flow.outgoing();
-      var listSize = 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 3;
-      var frameSize = 8 + 1 + 9 + 2 + listSize;
-      var expected = tu.buildBuffer([
-        0x00, 0x00, 0x00, frameSize,
-        0x02, 0x00, 0x00, 0x01,
-        0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x13,
-        0xc0, listSize, 11,
-        0x52, 1,
-        0x52, 100,
-        0x52, 1,
-        0x52, 100,
-        0x52, 1,
-        0x52, 2,
-        0x52, 100,
-        0x43,
-        0x42,
-        0x41,
-        0xc1, 1, 0
-      ]);
-      tu.shouldBufEql(expected, actual);
+  it('should encode performative correctly', function() {
+    var flow = new FlowFrame({
+      nextIncomingId: 1,
+      incomingWindow: 100,
+      nextOutgoingId: 1,
+      outgoingWindow: 100,
+      handle: 1,
+      deliveryCount: 2,
+      linkCredit: 100,
+      available: 0,
+      drain: false,
+      echo: true
     });
+    flow.channel = 1;
+    var actual = tu.convertFrameToBuffer(flow);
+    var listSize = 1 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 1 + 1 + 1 + 3;
+    var frameSize = 8 + 1 + 9 + 2 + listSize;
+    var expected = tu.buildBuffer([
+      0x00, 0x00, 0x00, frameSize,
+      0x02, 0x00, 0x00, 0x01,
+      0x00,
+      0x80, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x13,
+      0xc0, listSize, 11,
+      0x52, 1,
+      0x52, 100,
+      0x52, 1,
+      0x52, 100,
+      0x52, 1,
+      0x52, 2,
+      0x52, 100,
+      0x43,
+      0x42,
+      0x41,
+      0xc1, 1, 0
+    ]);
+
+    tu.shouldBufEql(expected, actual);
   });
 });
 
 describe('TransferFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode performative correctly', function() {
-      var transfer = new TransferFrame({
-        handle: 1,
-        deliveryId: 1,
-        deliveryTag: tu.buildBuffer([1]),
-        messageFormat: 20000,
-        settled: true,
-        receiverSettleMode: constants.receiverSettleMode.autoSettle
-      });
-      transfer.channel = 1;
-      transfer.message = new M.Message();
-      transfer.message.body.push(new ForcedType('uint', 10));
-      var actual = transfer.outgoing();
-      var payloadSize = 12;
-      var listSize = 1 + 2 + 2 + 3 + 5 + 1 + 1 + 2 + 1 + 1 + 1 + 1;
-      var frameSize = 8 + 1 + 9 + 2 + listSize + payloadSize;
-      var expected = tu.buildBuffer([
-        0x00, 0x00, 0x00, frameSize,
-        0x02, 0x00, 0x00, 0x01,
-        0x00,
-        0x80, 0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x14,
-        0xc0, listSize, 11,
-        0x52, 1, // handle
-        0x52, 1, // delivery-id
-        0xA0, 1, 1, // delivery-tag
-        0x70, builder.prototype.appendUInt32BE, 20000, // message-format
-        0x41, // settled
-        0x42, // more
-        0x50, 0, // rcv-settle-mode
-        0x40, // state
-        0x42, 0x42, 0x42, // resume/aborted/batchable
-        // Message Body - amqp-value of uint(10)
-        0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x77,
-        0x52, 10
-      ]);
-      tu.shouldBufEql(expected, actual);
+  it('should encode performative correctly', function() {
+    var transfer = new TransferFrame({
+      handle: 1,
+      deliveryId: 1,
+      deliveryTag: tu.buildBuffer([1]),
+      messageFormat: 20000,
+      settled: true,
+      receiverSettleMode: constants.receiverSettleMode.autoSettle
     });
+    transfer.channel = 1;
+    transfer.message = new M.Message();
+    transfer.message.body.push(new ForcedType('uint', 10));
+    var actual = tu.convertFrameToBuffer(transfer);
+    var payloadSize = 12;
+    var listSize = 1 + 2 + 2 + 3 + 5 + 1 + 1 + 2 + 1 + 1 + 1 + 1;
+    var frameSize = 8 + 1 + 9 + 2 + listSize + payloadSize;
+    var expected = tu.buildBuffer([
+      0x00, 0x00, 0x00, frameSize,
+      0x02, 0x00, 0x00, 0x01,
+      0x00,
+      0x80, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x14,
+      0xc0, listSize, 11,
+      0x52, 1, // handle
+      0x52, 1, // delivery-id
+      0xA0, 1, 1, // delivery-tag
+      0x70, builder.prototype.appendUInt32BE, 20000, // message-format
+      0x41, // settled
+      0x42, // more
+      0x50, 0, // rcv-settle-mode
+      0x40, // state
+      0x42, 0x42, 0x42, // resume/aborted/batchable
+      // Message Body - amqp-value of uint(10)
+      0x00, 0x80, 0, 0, 0, 0, 0, 0, 0, 0x77,
+      0x52, 10
+    ]);
+
+    tu.shouldBufEql(expected, actual);
   });
 });
 
 describe('SaslFrames', function() {
   describe('SaslMechanisms', function() {
-    describe('#outgoing()', function() {
-      it('should encode correctly', function() {
-        var mechanisms = new Sasl.SaslMechanisms();
-        var actual = mechanisms.outgoing();
-        var frameSize = 8 + 1 + 9 + 3 + 2 + 'ANONYMOUS'.length;
-        var expected = tu.buildBuffer([
-          0x00, 0x00, 0x00, frameSize,
-          0x02, 0x01, 0x00, 0x00,
-          0x00,
-          0x80, 0x00, 0x00, 0x00, 0x00,
-          0x00, 0x00, 0x00, 0x40,
-          0xC0, 9 + 3, 1,
-          0xA3, 9, builder.prototype.appendString, 'ANONYMOUS'
-        ]);
-        tu.shouldBufEql(expected, actual);
-      });
+    it('should encode correctly', function() {
+      var mechanisms = new Sasl.SaslMechanisms();
+      var actual = tu.convertFrameToBuffer(mechanisms);
+      var frameSize = 8 + 1 + 9 + 3 + 2 + 'ANONYMOUS'.length;
+      var expected = tu.buildBuffer([
+        0x00, 0x00, 0x00, frameSize,
+        0x02, 0x01, 0x00, 0x00,
+        0x00,
+        0x80, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x40,
+        0xC0, 9 + 3, 1,
+        0xA3, 9, builder.prototype.appendString, 'ANONYMOUS'
+      ]);
+
+      tu.shouldBufEql(expected, actual);
     });
   });
 });
 
 describe('HeartbeatFrame', function() {
-  describe('#outgoing()', function() {
-    it('should encode correctly', function() {
-      var heartbeat = new HeartbeatFrame();
-      var actual = heartbeat.outgoing();
-      var expected = tu.buildBuffer([0, 0, 0, 8, 2, 0, 0, 0]);
-      tu.shouldBufEql(expected, actual);
-    });
+  it('should encode correctly', function() {
+    var heartbeat = new HeartbeatFrame();
+    var actual = tu.convertFrameToBuffer(heartbeat);
+    var expected = tu.buildBuffer([0, 0, 0, 8, 2, 0, 0, 0]);
+    tu.shouldBufEql(expected, actual);
   });
 });

--- a/test/testing_utils.js
+++ b/test/testing_utils.js
@@ -3,9 +3,8 @@
 var builder = require('buffer-builder'),
     BufferList = require('bl'),
     should = require('should'),
-    _ = require('lodash');
-
-    var util = require('util');
+    _ = require('lodash'),
+    sb = require('stream-buffers');
 
 function buildBuffer(contents) {
   var bufb = new builder();
@@ -68,4 +67,10 @@ module.exports.assertTransitions = function(expectedTransitions, callback) {
 
     // @todo: should we display incorrect states?
   };
+};
+
+module.exports.convertFrameToBuffer = function(frame) {
+  var buffer = new sb.WritableStreamBuffer();
+  frame.write(buffer);
+  return buffer.getContents();
 };


### PR DESCRIPTION
A few things going on here:

 - remove all the temporary <frameType>buf() methods from tests,
   leading to a more declarative form for what the expected
   requests and responses are for a test sequence
 - removal of the Frame.outgoing helper function

This is the first step towards removing the buffer-builder from
the codebase. Since we are working with streams, there should be
no need to actually use a buffer builder. Now that this is in
place, we are able to use modules like buffer-more-ints to work
directly with streams (initially) for outgoing encoding.