### PR TITLE
Add posibility to attach ReceiverLink delayed in code & createReceiverLink promise will resolve immediatelly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="3.5.1"></a>
+## [3.5.1](https://github.com/noodlefrenzy/node-amqp10/compare/v3.5.0...v3.5.1) (2017-03-14)
+
+
+
 <a name="3.5.0"></a>
 # [3.5.0](https://github.com/noodlefrenzy/node-amqp10/compare/v3.4.2...v3.5.0) (2017-03-07)
 

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -313,7 +313,11 @@ AMQPClient.prototype.createReceiver = function(address, policyOverrides) {
       };
 
       var link = self._session.createLink(linkPolicy);
-      link._onAttach.push(attachPromise);
+      if (!linkPolicy.attach.manually) {
+        link._onAttach.push(attachPromise);
+      } else {
+        attachPromise(null, link);
+      }
     };
 
     attach();

--- a/lib/policies/policy.js
+++ b/lib/policies/policy.js
@@ -159,6 +159,7 @@ function Policy(overrides) {
      * @property {number|string} attach.receiverSettleMode The delivery settlement policy for the receiver
      * @property {number} attach.maxMessageSize The maximum message size supported by the link endpoint
      * @property {number} attach.initialDeliveryCount This must not be null if role is sender, and it is ignored if the role is receiver.
+     * @property {number} attach.manually To invoke attach self in your code set this option to true
      * @property {function} credit A function that determines when (if ever) to refresh the receiver link's credit
      * @property {number} creditQuantum Quantum used in pre-defined credit policy functions
      * @property {function|null} decoder=null The optional decoder used for all incoming data
@@ -170,7 +171,8 @@ function Policy(overrides) {
         role: constants.linkRole.receiver,
         receiverSettleMode: constants.receiverSettleMode.autoSettle,
         maxMessageSize: 10000, // Arbitrary choice
-        initialDeliveryCount: 1
+        initialDeliveryCount: 1,
+        manually: false
       },
       credit: putils.CreditPolicies.RefreshAtHalf,
       creditQuantum: 100,

--- a/lib/session.js
+++ b/lib/session.js
@@ -197,9 +197,11 @@ Session.prototype.createLink = function(linkPolicy) {
     self.emit(Session.ErrorReceived, err);
   });
 
-  if (this.mapped) {
-    // immediately attempt to attach link
-    link.attach();
+  if (!policy.attach.manually) {
+    if (this.mapped) {
+      // immediately attempt to attach link
+      link.attach();
+    }
   }
 
   return link;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amqp10",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Native AMQP-1.0 client for node.js",
   "main": "./lib",
   "engines": {
@@ -18,8 +18,8 @@
   "devDependencies": {
     "benchmark": "^2.1.2",
     "chai": "^3.5.0",
-    "chai-string": "^1.3.0",
     "chai-as-promised": "^6.0.0",
+    "chai-string": "^1.3.0",
     "conventional-changelog-cli": "^1.2.0",
     "gh-pages": "^0.12.0",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
* it is feature when you want to accept all messages even that it already waiting in queue. Otherwise the immediatelly attach will invoke receiving messages yarlier then event emmitter on('messasge'... can be registered.
* it has result that first messages are overlooked & never be consumed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/311)
<!-- Reviewable:end -->
