### PR TITLE
Update amqp_client.js with guard around reconnect

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -380,7 +380,7 @@ AMQPClient.prototype.disconnect = function() {
       });
       connection.close();
     } else {
-      debug("already disconnected")
+      debug("already disconnected");
       self.emit('disconnected');
       resolve(); // Already disconnected, just deliver the promise.
     }

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -186,6 +186,10 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
         self._timeouts = u.generateTimeouts(self.policy.reconnect);
 
       setTimeout(function() {
+        if (!self._reconnect) {
+            return;
+        }
+
         return self._attemptReconnection().then(function() { resolve(self); });
       }, self._timeouts.shift());
     });

--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -187,6 +187,7 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
 
       setTimeout(function() {
         if (!self._reconnect) {
+            self._clearConnectionState();
             return;
         }
 
@@ -354,8 +355,20 @@ AMQPClient.prototype.createReceiverStream = function(address, policyOverrides) {
 AMQPClient.prototype.disconnect = function() {
   var self = this;
   return new Promise(function(resolve, reject) {
-    debug('disconnecting');
+    debug('attempting to disconnect');
+
+    /*
+     * Problem: With reconnecting enabled, you can run into issues, for example, when you want to stop reconnecting (disconnect the connection),
+     * the app still tries to disconnect even after it has been successfully disconnected which results in it hanging.
+     *
+     * So we just need to make sure we aren't connected and clear the state so we don't try and disconnect an already disconnected connection.
+     */
+    if (self._connection && self._connection.connected === false) {
+        self._clearConnectionState(false);
+    }
+
     if (self._connection) {
+      debug('disconnecting');
       self._preventReconnect();
       var connection = self._connection;
       self._clearConnectionState();
@@ -367,6 +380,7 @@ AMQPClient.prototype.disconnect = function() {
       });
       connection.close();
     } else {
+      debug("already disconnected")
       self.emit('disconnected');
       resolve(); // Already disconnected, just deliver the promise.
     }


### PR DESCRIPTION
Stops the client attempting to reconnect when the client has been disconnected on purpose.

When disconnect has been called, `_preventReconnect()` gets called which sets `_reconnect = null`.
This guard has been added to stop the client from attempting to reconnect which will end with an error from `_attemptReconnection()` with regards to `return self._reconnect()` --  self._reconnect is not a function -- because it has been set to null

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/345)
<!-- Reviewable:end -->
