### PR TITLE
fixes #358 - the connection:opened event should be emited after all operations ?

### DIFF
--- a/lib/amqp_client.js
+++ b/lib/amqp_client.js
@@ -169,7 +169,6 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
     self._connection = self._newConnection(connectPolicy);
     self._connection.on(Connection.Connected, function(c) {
       debug('connected');
-      self.emit(AMQPClient.ConnectionOpened);
 
       var promises = [];
 
@@ -213,10 +212,12 @@ AMQPClient.prototype.connect = function(url, policyOverrides) {
         Promise.all(promises).then(function() {
           self.emit('connected');
           resolve(self);
+          self.emit(AMQPClient.ConnectionOpened);
         }).catch(reject);
       } else {
         self.emit('connected');
         resolve(self);
+        self.emit(AMQPClient.ConnectionOpened);
       }
     });
 


### PR DESCRIPTION
Creating receiver link right after 'connection:opened' event will get duplicated messages. Using process.nextTick() to create the link can avoid the issue. 

Please review whether this fix is appropriate or not...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/noodlefrenzy/node-amqp10/364)
<!-- Reviewable:end -->
